### PR TITLE
fix: you have to use a classifier to attach supplemental artifacts

### DIFF
--- a/src/main/java/io/bootique/tools/maven/BqPackageMojo.java
+++ b/src/main/java/io/bootique/tools/maven/BqPackageMojo.java
@@ -5,6 +5,7 @@ import io.bootique.tools.maven.recipe.Recipe;
 import io.bootique.tools.maven.recipe.ShadeRecipe;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -15,6 +16,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.util.Map;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -47,6 +51,13 @@ public class BqPackageMojo extends AbstractMojo {
     @Parameter(defaultValue = "assembly")
     private String mode;
 
+    /**
+    * If custom maven-jar-plugin declared in pom files of project, this flag must be on to use it
+    */
+    @Parameter(name = "useCustomJar", defaultValue = "false")
+    private String useCustomJar;
+
+
     public void execute() throws MojoExecutionException {
         ExecutionEnvironment environment = executionEnvironment(
                 mavenProject,
@@ -72,6 +83,7 @@ public class BqPackageMojo extends AbstractMojo {
                 recipe = new AssemblyRecipe(pluginExecutor);
         }
 
+        recipe.setUserJarPluginRequired(Boolean.parseBoolean(useCustomJar));
         recipe.execute();
     }
 

--- a/src/main/java/io/bootique/tools/maven/ConfigMerger.java
+++ b/src/main/java/io/bootique/tools/maven/ConfigMerger.java
@@ -16,7 +16,7 @@ public class ConfigMerger {
         this.log = Objects.requireNonNull(log);
     }
 
-    Xpp3Dom mergeWith(Xpp3Dom additionalConfig) {
+    public Xpp3Dom mergeWith(Xpp3Dom additionalConfig) {
         if(plugin != null && plugin.getConfiguration() != null && plugin.getConfiguration() instanceof Xpp3Dom) {
             Xpp3Dom existingConfig = (Xpp3Dom)plugin.getConfiguration();
             int i=0;

--- a/src/main/java/io/bootique/tools/maven/JarPluginUtils.java
+++ b/src/main/java/io/bootique/tools/maven/JarPluginUtils.java
@@ -1,0 +1,112 @@
+package io.bootique.tools.maven;
+
+import io.bootique.tools.maven.recipe.Recipe;
+import io.bootique.tools.maven.xml.XmlUtils;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.twdata.maven.mojoexecutor.MojoExecutor;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
+
+public class JarPluginUtils {
+    private final PluginExecutor pluginExecutor;
+    private final Recipe recipe;
+
+
+    public JarPluginUtils(Recipe recipe, PluginExecutor pluginExecutor) {
+        this.recipe = recipe;
+        this.pluginExecutor = pluginExecutor;
+    }
+
+    /**
+     * @return configuration of maven-jar-plugin with added classifier tag if conflict detected
+     */
+    public Xpp3Dom getAdditionalConfigurationIfNeededOrEmpty() {
+        Plugin plugin = pluginExecutor.getMavenProject().getPlugin("org.apache.maven.plugins:maven-jar-plugin");
+        Xpp3Dom configuration = configuration();
+        if (plugin != null) {
+            Object objConfiguration = plugin.getConfiguration();
+            configuration = (Xpp3Dom) objConfiguration;
+            String newClassifier = generateClassifierForConfiguration(configuration);
+
+            MojoExecutor.Element classifierElement = element("classifier", newClassifier);
+            if (configuration == null)
+                configuration = configuration(classifierElement);
+            else
+                configuration.addChild(classifierElement.toDom());
+
+        }
+        return configuration;
+    }
+
+    private static String generateClassifierForConfiguration(Xpp3Dom basicConfiguration) {
+        if (basicConfiguration == null)
+            return UUID.randomUUID().toString();
+        Xpp3Dom classifier = basicConfiguration.getChild("classifier");
+        if (classifier == null)
+            return UUID.randomUUID().toString();
+        String newClassifier;
+        do {
+            newClassifier = UUID.randomUUID().toString();
+        } while (classifier.getValue().equals(newClassifier));
+        return newClassifier;
+    }
+
+    /**
+     * @param artifact text representation of default maven-jar-plugin artifact in format groupId:artifactId:version
+     * @return custom maven-jar-plugin artifact if it declared in pom files and set as needed or default
+     * <p>
+     * Log info message if custom plugin not found and warning if custom maven-jar-plugin detected but not selected to use
+     */
+    public MavenArtifact getMavenArtifactOrDefault(String artifact) {
+        String[] parts = artifact.split(":");
+        if (parts.length != 3) {
+            throw new RuntimeException("incorrect artifact syntax");
+        }
+
+        boolean jarPluginDeclaredInPomFileOrParents = jarPluginDeclaredInPomFileOrParents(parts[0], parts[1]);
+
+        if (recipe.isUserJarPluginRequired()) {
+            if (!jarPluginDeclaredInPomFileOrParents) {
+                pluginExecutor.getLog().warn("Custom maven-jar-plugin not found; Default plugin will be in use");
+            } else {
+                Plugin plugin = pluginExecutor.getMavenProject().getPlugin(parts[0] + ":" + parts[1]);
+                if (plugin != null) {
+                    return new MavenArtifact(plugin.getGroupId(), plugin.getArtifactId(), plugin.getVersion());
+                }
+            }
+        } else if (jarPluginDeclaredInPomFileOrParents) {
+            pluginExecutor.getLog().info("Custom maven-jar-plugin detected; To use it set useCustomJar" +
+                    " parameter on true in bootique-maven-plugin configuration");
+        }
+
+        return new MavenArtifact(parts[0], parts[1], parts[2]);
+    }
+
+    private boolean jarPluginDeclaredInPomFileOrParents(String groupId, String artifactId) {
+        MavenProject currentMavenProject = pluginExecutor.getMavenProject();
+        while (currentMavenProject != null) {
+            File pomFile = currentMavenProject.getFile();
+            if (pluginDeclaredInFile(pomFile, groupId, artifactId))
+                return true;
+            currentMavenProject = currentMavenProject.getParent();
+        }
+        return false;
+    }
+
+    private boolean pluginDeclaredInFile(File pomFile, String groupId, String artifactId) {
+        Map<String, String> nodesWithValues = new HashMap<String, String>() {{
+            put("groupId", groupId);
+            put("artifactId", artifactId);
+        }};
+
+        return XmlUtils.hasNodeWithCurrentChildNodesValues(pomFile, "plugin", nodesWithValues);
+    }
+}

--- a/src/main/java/io/bootique/tools/maven/PluginExecutor.java
+++ b/src/main/java/io/bootique/tools/maven/PluginExecutor.java
@@ -79,6 +79,10 @@ public class PluginExecutor {
         }
     }
 
+    public MavenProject getMavenProject() {
+        return mavenProject;
+    }
+
     public Log getLog() {
         return log;
     }

--- a/src/main/java/io/bootique/tools/maven/recipe/AssemblyRecipe.java
+++ b/src/main/java/io/bootique/tools/maven/recipe/AssemblyRecipe.java
@@ -1,11 +1,12 @@
 package io.bootique.tools.maven.recipe;
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
+import java.util.*;
 
+import io.bootique.tools.maven.JarPluginUtils;
 import io.bootique.tools.maven.MavenArtifact;
 import io.bootique.tools.maven.PluginExecutor;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import static java.util.Collections.singletonList;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
@@ -17,6 +18,7 @@ public class AssemblyRecipe extends Recipe {
 
     private static final String VERSION_BUNDLE = "io.bootique.tools.maven.version";
     private static final String PLUGIN_VERSION;
+
     static {
         PLUGIN_VERSION = getVersionBundle().getString("project.version");
     }
@@ -32,24 +34,15 @@ public class AssemblyRecipe extends Recipe {
         executeAssemblyPlugin();
     }
 
-    void executeJarPlugin() throws MojoExecutionException {
-        MavenArtifact artifact = new MavenArtifact(
-                "org.apache.maven.plugins",
-                "maven-jar-plugin",
-                "3.2.0"
-        );
-
-        pluginExecutor.execute(
-                artifact,
-                goal("jar"),
-                configuration(
-                        element(name("archive"),
-                                element("manifest",
-                                        element("mainClass", "${main.class}"),
-                                        element("addClasspath", "true"),
-                                        element("classpathPrefix", "lib/"),
-                                        element("useUniqueVersions", "false")
-                                )
+    @Override
+    protected Xpp3Dom getDefaultJarConfig() {
+        return configuration(
+                element(name("archive"),
+                        element("manifest",
+                                element("mainClass", "${main.class}"),
+                                element("addClasspath", "true"),
+                                element("classpathPrefix", "lib/"),
+                                element("useUniqueVersions", "false")
                         )
                 )
         );

--- a/src/main/java/io/bootique/tools/maven/recipe/Recipe.java
+++ b/src/main/java/io/bootique/tools/maven/recipe/Recipe.java
@@ -2,10 +2,17 @@ package io.bootique.tools.maven.recipe;
 
 import java.util.Objects;
 
+import io.bootique.tools.maven.JarPluginUtils;
+import io.bootique.tools.maven.MavenArtifact;
 import io.bootique.tools.maven.PluginExecutor;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 public abstract class Recipe {
+
+    private boolean userJarPluginRequired = false;
 
     protected final PluginExecutor pluginExecutor;
 
@@ -14,4 +21,32 @@ public abstract class Recipe {
     }
 
     public abstract void execute() throws MojoExecutionException;
+
+    public void setUserJarPluginRequired(boolean userJarPluginRequired) {
+        this.userJarPluginRequired = userJarPluginRequired;
+    }
+
+    /**
+     * Sets sequence of maven-jar-plugin execution steps
+     */
+    protected void executeJarPlugin() throws MojoExecutionException {
+        JarPluginUtils jarPluginUtils = new JarPluginUtils(this, pluginExecutor);
+
+        MavenArtifact artifact
+                = jarPluginUtils.getMavenArtifactOrDefault("org.apache.maven.plugins:maven-jar-plugin:3.2.0");
+        Xpp3Dom additionalConfig = jarPluginUtils.getAdditionalConfigurationIfNeededOrEmpty();
+
+        Xpp3Dom defaultConfig = getDefaultJarConfig();
+        pluginExecutor.execute(
+                artifact,
+                goal("jar"),
+                Xpp3Dom.mergeXpp3Dom(defaultConfig, additionalConfig)
+        );
+    }
+
+    protected abstract Xpp3Dom getDefaultJarConfig();
+
+    public boolean isUserJarPluginRequired() {
+        return userJarPluginRequired;
+    }
 }

--- a/src/main/java/io/bootique/tools/maven/recipe/ShadeRecipe.java
+++ b/src/main/java/io/bootique/tools/maven/recipe/ShadeRecipe.java
@@ -3,6 +3,7 @@ package io.bootique.tools.maven.recipe;
 import io.bootique.tools.maven.MavenArtifact;
 import io.bootique.tools.maven.PluginExecutor;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -21,18 +22,9 @@ public class ShadeRecipe extends Recipe {
         executeShadePlugin();
     }
 
-    void executeJarPlugin() throws MojoExecutionException {
-        MavenArtifact artifact = new MavenArtifact(
-                "org.apache.maven.plugins",
-                "maven-jar-plugin",
-                "3.2.0"
-        );
-
-        pluginExecutor.execute(
-                artifact,
-                goal("jar"),
-                configuration()
-        );
+    @Override
+    protected Xpp3Dom getDefaultJarConfig() {
+        return configuration();
     }
 
     void executeShadePlugin() throws MojoExecutionException {

--- a/src/main/java/io/bootique/tools/maven/xml/XmlUtils.java
+++ b/src/main/java/io/bootique/tools/maven/xml/XmlUtils.java
@@ -1,0 +1,63 @@
+package io.bootique.tools.maven.xml;
+
+import org.w3c.dom.*;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+
+public class XmlUtils {
+
+    /**
+     * @param pomFile file where node can be found
+     * @param rootNodeTag name of the root element of the needed node
+     * @param nodesWithValues map of pairs ['node name', 'node text value'], child node of the rootNodeTag with
+     *                        current 'node name' must have text, that contains 'node text value'
+     * @return true if node was found
+     */
+    public static boolean hasNodeWithCurrentChildNodesValues(File pomFile, String rootNodeTag,
+                                                             Map<String, String> nodesWithValues) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder db = factory.newDocumentBuilder();
+
+            Document doc = db.parse(pomFile);
+            NodeList pluginElements = doc.getElementsByTagName(rootNodeTag);
+            for (int i = 0; i < pluginElements.getLength(); i++) {
+                Element element = (Element) pluginElements.item(i);
+                if(elementHasValues(element, nodesWithValues))
+                    return true;
+            }
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    private static boolean elementHasValues(Element element, Map<String, String> nodesWithValues){
+        boolean nodeHasValues = true;
+        Set<Map.Entry<String, String>> entries = nodesWithValues.entrySet();
+        for (Map.Entry<String, String> entry : entries) {
+            Node node = element.getElementsByTagName(entry.getKey()).item(0);
+            if (!nodeHasText(node, entry.getValue())) {
+                nodeHasValues = false;
+                break;
+            }
+        }
+        return nodeHasValues;
+    }
+
+    private static boolean nodeHasText(Node node, String text) {
+        if (text == null)
+            return true;
+        if (node == null)
+            return false;
+        return node.getTextContent().contains(text);
+    }
+}


### PR DESCRIPTION
- add flag useCustomJar to plugin, which sets if user wants to use customized maven-jar-plugin declared in pom files
- add warning and info messages if flag is set but custom plugin not detected and if custom plugin detected but not selected to use
- change mergeWith method access level in ConfigMerger class to public to use it in util classes
- feat classifier generation for maven-jar-plugin if it is required
- move executeJarPlugin invoke to the top level of hierarchy to avoid code duplication
- add xml util classes to check if maven-jar-plugin declared in pom file of the project or it's parents
- document necessary public methods in added classes